### PR TITLE
CronJob

### DIFF
--- a/chapter-02/gitops-cronjob.yaml
+++ b/chapter-02/gitops-cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: gitops-cron


### PR DESCRIPTION
CronJob 
The batch/v1beta1 API version of CronJob will no longer be served in v1.25.